### PR TITLE
Fix compatibility with usb 2.x and Node 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,470 +1,95 @@
 {
 	"name": "ant-plus",
 	"version": "0.1.25",
-	"lockfileVersion": 1,
+	"lockfileVersion": 3,
 	"requires": true,
-	"dependencies": {
-		"@types/node": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.2.tgz",
-			"integrity": "sha512-JWB3xaVfsfnFY8Ofc9rTB/op0fqqTSqy4vBcVk1LuRJvta7KTX+D//fCkiTMeLGhdr2EbFZzQjC97gvmPilk9Q==",
-			"dev": true
+	"packages": {
+		"": {
+			"name": "ant-plus",
+			"version": "0.1.25",
+			"license": "MIT",
+			"dependencies": {
+				"usb": "^2.17.0"
+			},
+			"devDependencies": {
+				"@types/node": "^20.0.0",
+				"typescript": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
 		},
-		"@types/usb": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@types/usb/-/usb-1.5.1.tgz",
-			"integrity": "sha512-1qhcYMLJ0I2HcRG3G/nBcRZ0KrrTdGdUNcCkEVgcga4KMlDXWh6LZJjVA6MiWEDa+BOaQTEfGJfuNaQ71IQOpg==",
+		"node_modules/@types/node": {
+			"version": "20.19.34",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.34.tgz",
+			"integrity": "sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==",
 			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			}
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bl": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-			"integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
-			"requires": {
-				"readable-stream": "^3.0.1"
-			},
+			"license": "MIT",
 			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
+				"undici-types": "~6.21.0"
 			}
 		},
-		"chownr": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+		"node_modules/@types/w3c-web-usb": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.13.tgz",
+			"integrity": "sha512-N2nSl3Xsx8mRHZBvMSdNGtzMyeleTvtlEw+ujujgXalPqOjIA6UtrqcB6OzyUjkTbDm3J7P1RNK1lgoO7jxtsw==",
+			"license": "MIT"
 		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-		},
-		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"requires": {
-				"mimic-response": "^1.0.0"
+		"node_modules/node-addon-api": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+			"integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18 || ^20 || >= 21"
 			}
 		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-		},
-		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"requires": {
-				"once": "^1.4.0"
+		"node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		},
-		"expand-template": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-		},
-		"fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			}
-		},
-		"github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-		},
-		"is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-		},
-		"mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-		},
-		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-		},
-		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"requires": {
-				"minimist": "0.0.8"
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
 			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/usb": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/usb/-/usb-2.17.0.tgz",
+			"integrity": "sha512-UuFgrlglgDn5ll6d5l7kl3nDb2Yx43qLUGcDq+7UNLZLtbNug0HZBb2Xodhgx2JZB1LqvU+dOGqLEeYUeZqsHg==",
+			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-				}
-			}
-		},
-		"nan": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
-		},
-		"napi-build-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
-			"integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
-		},
-		"node-abi": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.11.0.tgz",
-			"integrity": "sha512-kuy/aEg75u40v378WRllQ4ZexaXJiCvB68D2scDXclp/I4cRq6togpbOoKhmN07tns9Zldu51NNERo0wehfX9g==",
-			"requires": {
-				"semver": "^5.4.1"
-			}
-		},
-		"noop-logger": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"prebuild-install": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.1.tgz",
-			"integrity": "sha512-lRLBU0JPXBbpC/ER9PtVYYk1y9Rme1WiMA3WKEQ4v78A5kTsqQtrEyYlbghvXCA6Uhr/769SkhibQznjDBRZpg==",
-			"requires": {
-				"detect-libc": "^1.0.3",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"napi-build-utils": "^1.0.1",
-				"node-abi": "^2.7.0",
-				"noop-logger": "^0.1.1",
-				"npmlog": "^4.0.1",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^3.0.3",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0",
-				"which-pm-runs": "^1.0.0"
-			}
-		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-		},
-		"pump": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
-		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-		},
-		"signal-exit": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-		},
-		"simple-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-		},
-		"simple-get": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.0.3.tgz",
-			"integrity": "sha512-Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==",
-			"requires": {
-				"decompress-response": "^3.3.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"string-width": {
-			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
-			}
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-		},
-		"tar-fs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
-			"integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
-			"requires": {
-				"chownr": "^1.1.1",
-				"mkdirp": "^0.5.1",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.0.0"
-			}
-		},
-		"tar-stream": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-			"integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
-			"requires": {
-				"bl": "^3.0.0",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
+				"@types/w3c-web-usb": "^1.0.6",
+				"node-addon-api": "^8.0.0",
+				"node-gyp-build": "^4.5.0"
 			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
+			"engines": {
+				"node": ">=12.22.0 <13.0 || >=14.17.0"
 			}
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"typescript": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
-			"dev": true
-		},
-		"usb": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/usb/-/usb-1.6.0.tgz",
-			"integrity": "sha512-52DyWlCk9K+iw3LnvY95WXSnpHjxJoI++aGkV8HiMNPc4zmvDQlYvWAzrkbJ2JH3oUcx26XfU5sZcG4RAcVkMg==",
-			"requires": {
-				"bindings": "^1.4.0",
-				"nan": "2.13.2",
-				"prebuild-install": "^5.2.4"
-			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"which-pm-runs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
-		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -17,15 +17,14 @@
 	},
 	"license": "MIT",
 	"engines": {
-		"node": ">=6.0.0"
+		"node": ">=16.0.0"
 	},
 	"dependencies": {
-		"usb": "^1.6.0"
+		"usb": "^2.17.0"
 	},
 	"devDependencies": {
-		"typescript": "^3.6.4",
-		"@types/node": "^6.0.0",
-		"@types/usb": "^1.5.1"
+		"typescript": "^5.0.0",
+		"@types/node": "^20.0.0"
 	},
 	"files": [
 		"ant-plus.js",

--- a/src/ant.ts
+++ b/src/ant.ts
@@ -1,6 +1,6 @@
 import events = require('events');
 
-import usb = require('usb');
+import { usb, Device, Interface, InEndpoint, OutEndpoint } from 'usb';
 
 export enum Constants {
 	MESSAGE_RF = 0x01,
@@ -297,7 +297,6 @@ class CancellationTokenListener {
 	cancel() {
 		if (!this._completed) {
 			this._completed = true;
-			// @ts-ignore
 			usb.removeListener('attach', this.fn);
 			this.cb(new Error('Canceled'));
 		}
@@ -305,12 +304,12 @@ class CancellationTokenListener {
 }
 
 export class USBDriver extends events.EventEmitter {
-	private static deviceInUse: usb.Device[] = [];
-	private device: usb.Device;
-	private iface: usb.Interface;
+	private static deviceInUse: Device[] = [];
+	private device: Device;
+	private iface: Interface;
 	private detachedKernelDriver = false;
-	private inEp: usb.InEndpoint & events.EventEmitter;
-	private outEp: usb.OutEndpoint & events.EventEmitter;
+	private inEp: InEndpoint & events.EventEmitter;
+	private outEp: OutEndpoint & events.EventEmitter;
 	private leftover: Buffer;
 	private usedChannels: number = 0;
 	private attachedSensors: BaseSensor[] = [];
@@ -364,7 +363,7 @@ export class USBDriver extends events.EventEmitter {
 		}
 		USBDriver.deviceInUse.push(this.device);
 
-		this.inEp = this.iface.endpoints[0] as usb.InEndpoint;
+		this.inEp = this.iface.endpoints[0] as InEndpoint;
 
 		this.inEp.on('data', (data: Buffer) => {
 			if (!data.length) {
@@ -409,7 +408,7 @@ export class USBDriver extends events.EventEmitter {
 
 		this.inEp.startPoll();
 
-		this.outEp = this.iface.endpoints[1] as usb.OutEndpoint;
+		this.outEp = this.iface.endpoints[1] as OutEndpoint;
 
 		this.reset();
 
@@ -439,14 +438,12 @@ export class USBDriver extends events.EventEmitter {
 		const fn = (d) => {
 			if (!d || (d.deviceDescriptor.idVendor === this.idVendor && d.deviceDescriptor.idProduct === this.idProduct)) {
 				if (doOpen()) {
-					// @ts-ignore
 					usb.removeListener('attach', fn);
 				}
 			}
 		};
 		usb.on('attach', fn);
 		if (this.is_present()) {
-			// @ts-ignore
 			setImmediate(() => usb.emit('attach', this.device));
 		}
 		return ct = new CancellationTokenListener(fn, cb);
@@ -473,9 +470,7 @@ export class USBDriver extends events.EventEmitter {
 					if (devIdx >= 0) {
 						USBDriver.deviceInUse.splice(devIdx, 1);
 					}
-					// @ts-ignore
 					if (usb.listenerCount('attach')) {
-						// @ts-ignore
 						usb.emit('attach', this.device);
 					}
 					this.device = undefined;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,11 @@
 {
 	"compilerOptions": {
-		"target": "ES5",
+		"target": "ES2017",
+		"lib": ["ES2017"],
 		"module": "commonjs",
 		"sourceMap": true,
 		"outDir": "build",
-		"declaration": true
+		"declaration": true,
+		"skipLibCheck": true
 	}
 }


### PR DESCRIPTION
- Update usb dependency from ^1.6.0 to ^2.17.0; usb 1.x crashes on Node 20 with a fatal napi_create_reference error in the hotplug callback
- Update import in src/ant.ts to use the named `usb` export from usb 2.x, which moved event emitter methods (on/emit/removeListener/etc) to a sub-export
- Remove now-unnecessary @ts-ignore comments; usb 2.x ships proper types
- Update @types/node to ^20.0.0, typescript to ^5.0.0, and target ES2017 to match the requirements of the new usb and TypeScript versions
- Add skipLibCheck: true to tsconfig to avoid errors in third-party types
- Update engines field to reflect actual Node.js compatibility (>=16)